### PR TITLE
Improved reliability of Fleet removal

### DIFF
--- a/Tweak.x
+++ b/Tweak.x
@@ -1,11 +1,5 @@
 %hook T1FleetLineHeaderViewController
-
-- (id)view {
-	id view = %orig;
-	[(UIView *)view setHidden:YES];
-	return view;
+- (void)_t1_configureFleets {
+	return;
 }
-
-- (void)setFleetLineView:(id)arg1 {}
-
 %end


### PR DESCRIPTION
Since a few people reported that this tweak isn't working (it isn't working for myself either on an iPhone X, 13.6.1), I've found a method of removing Fleets that's way more simple: By preventing the `T1FleetLineHeaderViewController` to even initialize Fleets whatsoever.

This also prevents views from being shifted (if at all) and should work with future versions.